### PR TITLE
Fix typo in "void Koan01_number_types::floats_have_a_size".

### DIFF
--- a/koans/koan01_number_types.cpp
+++ b/koans/koan01_number_types.cpp
@@ -54,7 +54,7 @@ void Koan01_number_types::simple_floats()
 
 void Koan01_number_types::floats_have_a_size()
 {
-  int a_float = 4.2;
+  float a_float = 4.2;
   ASSERT_EQUAL( sizeof( float ), FILL_THE_NUMBER_IN );
   ASSERT_EQUAL( sizeof( a_float ), FILL_THE_NUMBER_IN );
 }


### PR DESCRIPTION
Use float type instead of int for the a_float variable.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/torbjoernk/cppkoans/2)

<!-- Reviewable:end -->
