### PR TITLE
Added spaces in headers to take advantage of GFM

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,18 +1,18 @@
-#CppKoans
+# CppKoans
 
-Inspired by [RubyKoans](https://github.com/edgecase/ruby_koans) and 
+Inspired by [RubyKoans](https://github.com/edgecase/ruby_koans) and
 [JavaScript-Koans](https://github.com/liammclennan/JavaScript-Koans), this is
 an attempt to write such koans for C/C++.
 
 Some ideas were taken from [PointerKoans](https://github.com/paytonrules/PointerKoan).
 
-###Prerequesites
+### Prerequesites
 You will need [CMake](http://cmake.org/).
 
 And of course a C++ compiler.
 I just tested it with a recent GCC.
 
-##How to walk the path to enlightment
+## How to walk the path to enlightment
 1. Get the sources
 
         git clone git://github.com/torbjoernk/CppKoans.git
@@ -50,8 +50,8 @@ Thus, walking the path to enlightment is a repetition of these steps:
 3. Read the master's reply with `./CppKoans/build/CppKoans`
 
 
-##Adding further Koans
-###To existing episodes
+## Adding further Koans
+### To existing episodes
 Just define a new `private void` function without parameters in the bottom
 section of the episode's header file it should belong to.
 Then go to the implementation file of that episode and implement your new koan.
@@ -59,7 +59,7 @@ Finally add your newly created koan to the `run()` function in the header file
 of that episode and increase the `num_tests` counter by one (or whatevery amount
 of koans you added).
 
-###New episodes
+### New episodes
 There is a sample episode, which can be used as a template for new episodes.
 After copying and renaming of `~/headers/koanXX_sample_koans.hpp` and
 `~/koans/koanXX_sample_koans.cpp` the following steps are necessary:


### PR DESCRIPTION
There were spaces missing between the # symbol and the header text for Github Flavored Markdown to properly render the README.